### PR TITLE
Fix description and protocol naming merging to master

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -15,9 +15,8 @@ resource "aws_security_group" "allow_ssh" {
 
     ingress {
       description = "TLS from VPC"
-      from_port = 22
-      to_port = 22
       protocol = "ssh"
+      cidr_blocks = ["0.0.0.0/0"]
     }
 }
 

--- a/instance.tf
+++ b/instance.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "allow_ssh" {
     vpc_id = aws_vpc.core-infra.id
 
     ingress {
-      description = "allow ssh through tcp protocol"
+      description = "ssh with tcp"
       from_port = 22
       to_port = 22
       protocol = "tcp"

--- a/instance.tf
+++ b/instance.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "allow_ssh" {
     vpc_id = aws_vpc.core-infra.id
 
     ingress {
-      description = "TCP from VPC"
+      description = "allow ssh through tcp protocol"
       from_port = 22
       to_port = 22
       protocol = "tcp"

--- a/instance.tf
+++ b/instance.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "allow_ssh" {
     vpc_id = aws_vpc.core-infra.id
 
     ingress {
-      description = "ssh with tcp"
+      description = "Allow SSH Connection"
       from_port = 22
       to_port = 22
       protocol = "tcp"

--- a/instance.tf
+++ b/instance.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "allow_ssh" {
     vpc_id = aws_vpc.core-infra.id
 
     ingress {
-      description = "TLS from VPC"
+      description = "SSH from VPC"
       from_port = 22
       to_port = 22
       protocol = "ssh"

--- a/instance.tf
+++ b/instance.tf
@@ -14,10 +14,10 @@ resource "aws_security_group" "allow_ssh" {
     vpc_id = aws_vpc.core-infra.id
 
     ingress {
-      description = "SSH from VPC"
+      description = "TCP from VPC"
       from_port = 22
       to_port = 22
-      protocol = "ssh"
+      protocol = "tcp"
       cidr_blocks = ["0.0.0.0/0"]
     }
 }

--- a/instance.tf
+++ b/instance.tf
@@ -15,6 +15,8 @@ resource "aws_security_group" "allow_ssh" {
 
     ingress {
       description = "TLS from VPC"
+      from_port = 22
+      to_port = 22
       protocol = "ssh"
       cidr_blocks = ["0.0.0.0/0"]
     }


### PR DESCRIPTION
Fix description of the security group description and adjust protocol naming from "ssh" to "tcp".